### PR TITLE
Some small dev setup improvements

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,3 @@
+export IMAGE=$(whoami)/tweed-kernel
+export VERSION=edge
+export NAMESPACE=tweed-$(whoami)

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.saferc
 /.svtoken
 /test/logs
+/.envrc

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-IMAGE := tweedproject/kernel
+IMAGE ?= tweedproject/kernel
+NAMESPACE ?= tweed
 
-VERSION ?= 
+VERSION ?=
 BUILD   ?= $(shell ./build/build-number)
 LDFLAGS := -X main.Version="$(VERSION)" -X main.BuildNumber="$(BUILD)"
 
@@ -11,13 +12,20 @@ default:
 docker:
 	docker build -t $(IMAGE):edge .
 
+deploy:
+	cat eval.yml | \
+	  IMAGE=$(IMAGE) \
+          VERSION=$(VERSION) \
+	  NAMESPACE=$(NAMESPACE) \
+          envsubst | kubectl apply -f -
+
 push: default
 	@echo "Checking that VERSION was defined in the calling environment"
 	@test -n "$(VERSION)"
 	@echo "OK.  VERSION=$(VERSION)"
-	
+
 	docker build -t $(IMAGE):$(VERSION) .
-	
+
 	docker push $(IMAGE):$(VERSION)
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
 	for V in $(VERSION) $(shell echo "$(VERSION)" | sed -e 's/\.[^.]*$$//') $(shell echo "$(VERSION)" | sed -e 's/\..*$$//'); do \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ VERSION ?=
 BUILD   ?= $(shell ./build/build-number)
 LDFLAGS := -X main.Version="$(VERSION)" -X main.BuildNumber="$(BUILD)"
 
+.PHONY: test
+
 default:
 	go fmt . ./api ./cmd/tweed
 	go build -ldflags="$(LDFLAGS)" ./cmd/tweed
@@ -34,5 +36,4 @@ push: default
 	done
 
 test:
-	./test/the shared
-	./test/the dedicated
+	./test/the all

--- a/eval.yml
+++ b/eval.yml
@@ -83,7 +83,7 @@ data:
                 PostgreSQL version 9.x
               tweed:
                 infrastructure: k8s
-                stencil:  postgres/standalone/k8s
+                stencil:  postgres/standalone
                 limit:  2
                 config:
                   version: '9'
@@ -97,7 +97,7 @@ data:
                 PostgreSQL version 10.x
               tweed:
                 infrastructure: k8s
-                stencil:  postgres/standalone/k8s
+                stencil:  postgres/standalone
                 limit: 1
                 config:
                   version: '10'
@@ -111,8 +111,8 @@ data:
                 PostgreSQL version 11.x
               tweed:
                 infrastructure: k8s
-                stencil:  postgres/standalone/k8s
-                limit: 1
+                stencil:  postgres/standalone
+                limit: o1
                 config:
                   version: '11'
                 credentials:

--- a/eval.yml
+++ b/eval.yml
@@ -2,19 +2,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: tweed
+  name: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tweed
-  namespace: tweed
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tweed-broker
-  namespace: tweed
+  namespace: ${NAMESPACE}
 rules:
   - apiGroups: ["", "batch", "extensions", "apps"]
     resources: ["*"]
@@ -24,11 +24,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tweed
-  namespace: tweed
+  namespace: ${NAMESPACE}
 subjects:
   - kind: ServiceAccount
     name: tweed
-    namespace: tweed
+    namespace: ${NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: tweed-broker
@@ -38,7 +38,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:      vault
-  namespace: tweed
+  namespace: ${NAMESPACE}
 data:
   local.json: |
     {
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:      tweed
-  namespace: tweed
+  namespace: ${NAMESPACE}
 data:
   tweed.yml: |
     prefix: ''
@@ -123,7 +123,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name:      tweed
-  namespace: tweed
+  namespace: ${NAMESPACE}
   labels:
     app:     tweed
     env:     eval
@@ -165,7 +165,7 @@ spec:
               mountPath: /vault/config
 
         - name:  broker
-          image: huntprod/tweed:latest
+          image: ${IMAGE}:${VERSION}
           imagePullPolicy: Always
           env:
             - name:  INIT_VAULT
@@ -201,7 +201,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tweed
-  namespace: tweed
+  namespace: ${NAMESPACE}
   labels:
     app:     tweed
     env:     eval

--- a/eval.yml
+++ b/eval.yml
@@ -16,7 +16,7 @@ metadata:
   name: tweed-broker
   namespace: ${NAMESPACE}
 rules:
-  - apiGroups: ["", "batch", "extensions", "apps"]
+  - apiGroups: ["", "batch", "extensions", "apps", "autoscaling"]
     resources: ["*"]
     verbs:     ["*"]
 ---

--- a/test/envrc.k8s
+++ b/test/envrc.k8s
@@ -1,0 +1,5 @@
+host=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+port=$(kubectl -n ${NAMESPACE} get service tweed -o jsonpath='{.spec.ports[0].nodePort}')
+export TWEED_URL=http://${host}:${port}
+export TWEED_USERNAME=tweed
+export TWEED_PASSWORD=tweed


### PR DESCRIPTION
Around deploying and testing on k8s

```
cat .envrc.sample test/envrc.k8s > .envrc
make push
make deploy
./test/the
```

I'm still not sure what the proper use of `./test/the` is.

Invoking via `make` does not work yet:
```
make test
make: `test' is up to date.
```